### PR TITLE
feat: working S3 upload routes (/ and /upload,/upload2)

### DIFF
--- a/flask-s3-service/app.py
+++ b/flask-s3-service/app.py
@@ -1,56 +1,64 @@
-import os#
-import logging
-import boto3
-from flask import Flask, request, render_template_string
+from flask import Flask, request, Response
 from werkzeug.utils import secure_filename
-
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(name)s - %(message)s"
-)
-logger = logging.getLogger(__name__)
+import boto3, os, logging
 
 app = Flask(__name__)
+log = logging.getLogger(__name__)
 
-AWS_REGION = os.environ["AWS_REGION"]
-BUCKET_NAME = os.environ["BUCKET_NAME"]
-s3_client = boto3.client("s3", region_name=AWS_REGION)
+# Environment
+AWS_REGION = os.environ.get("AWS_REGION", "ap-southeast-1")
+BUCKET_NAME = os.environ["BUCKET_NAME"]  # must be set
 
-# Simple HTML form for file upload
-UPLOAD_FORM = """
-<!DOCTYPE html>
-<html>
-  <body>
-    <h1>Upload a File to S3</h1>
-    <form method="POST" action="/upload" enctype="multipart/form-data">
-      <label>Select file:</label>
-      <input type="file" name="file" required/>
-      <br/><br/>
-      <button type="submit">Upload</button>
-    </form>
-  </body>
-</html>
-"""
+s3 = boto3.client("s3", region_name=AWS_REGION)
+
+@app.route("/", methods=["GET"])
+def index():
+    return (
+        f"Flask S3 service is running.<br>"
+        f"Bucket: {BUCKET_NAME}<br>"
+        f"Try <a href='/upload'>/upload</a> or <a href='/upload2'>/upload2</a>.",
+        200,
+    )
+
+def _handle_upload(form_field: str):
+    if form_field not in request.files:
+        return Response(f"No file field named '{form_field}' in form", status=400)
+    f = request.files[form_field]
+    if f.filename == "":
+        return Response("No file selected", status=400)
+
+    filename = secure_filename(f.filename)
+    try:
+        s3.upload_fileobj(f, BUCKET_NAME, filename)
+        log.info("Uploaded %s to s3://%s/%s", filename, BUCKET_NAME, filename)
+        return f"Uploaded {filename} to s3://{BUCKET_NAME}/{filename}\n", 200
+    except Exception as e:
+        log.exception("Upload failed")
+        return Response(f"Upload failed: {e}", status=500)
 
 @app.route("/upload", methods=["GET", "POST"])
-def upload_file():
+def upload():
     if request.method == "GET":
-        return render_template_string(UPLOAD_FORM)
+        return '''
+        <h1>Upload a File to S3 (/upload)</h1>
+        <form method="POST" enctype="multipart/form-data">
+          <input type="file" name="file">
+          <button type="submit">Upload</button>
+        </form>
+        ''', 200
+    return _handle_upload("file")
 
-    file_obj = request.files.get("file")
-    if not file_obj or file_obj.filename.strip() == "":
-        logger.warning("No valid file provided.")
-        return "No valid file provided.", 400
-
-    filename = secure_filename(file_obj.filename)
-
-    try:
-        s3_client.upload_fileobj(file_obj, BUCKET_NAME, filename)
-        logger.info("File '%s' uploaded to bucket '%s'.", filename, BUCKET_NAME)
-        return f"File '{filename}' uploaded successfully to S3 bucket '{BUCKET_NAME}'!"
-    except Exception as exc:
-        logger.exception("Error uploading file to S3.")
-        return f"Error uploading file: {str(exc)}", 500
+@app.route("/upload2", methods=["GET", "POST"])
+def upload2():
+    if request.method == "GET":
+        return '''
+        <h1>Upload a File to S3 (/upload2)</h1>
+        <form method="POST" enctype="multipart/form-data">
+          <input type="file" name="file">
+          <button type="submit">Upload</button>
+        </form>
+        ''', 200
+    return _handle_upload("file")
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=5001)


### PR DESCRIPTION
- Added Flask routes: `/` (index), `/upload`, `/upload2`
- App uses env vars `BUCKET_NAME` + `AWS_REGION`; runs on port 5001
- Created S3 bucket via Terraform: ce10grp2-flask-s3-63bece1c (ap-southeast-1)
- Tested locally: uploaded `test-upload.txt` to the bucket successfully